### PR TITLE
Duplicate items in cart - Fixed

### DIFF
--- a/src/js/ProductDetails.mjs
+++ b/src/js/ProductDetails.mjs
@@ -36,7 +36,13 @@ export default class ProductDetails {
 
     addToCart() {
         let cart = getLocalStorage("so-cart") || [];
-        cart.unshift(this.product);
+        let isProductInCart = cart.some(item => item.Id === this.product.Id); //boolean to see if the product is in the array.
+        if (isProductInCart) {
+            const index = cart.findIndex(item => item.Id === this.product.Id); //Find the index where the quantity needs to be changed.
+            cart[index].quantity += 1; //Adds to the quantity
+        } else {
+            this.product.quantity = 1; // Set quantity to 1
+            cart.unshift(this.product);} // Add product to the array of cart
         setLocalStorage("so-cart", cart);
         // setLocalStorage("so-cart", this.product);
     }

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -20,9 +20,9 @@ function cartItemTemplate(item) {
     <h2 class="card__name">${item.Name}</h2>
   </a>
   <p class="cart-card__color">${item.Colors[0].ColorName}</p>
-  <p class="cart-card__quantity">qty: 1<span data-id= "${item.Id} " class="deleteBtn"> ❌</span></p>
-  <p class="cart-card__price">$${item.FinalPrice}</p>
-</li>`;
+  <p class="cart-card__quantity">qty: ${item.quantity}<span data-id= "${item.Id} " class="deleteBtn"> ❌</span></p>
+  <p class="cart-card__price">$${(item.FinalPrice * item.quantity).toFixed(2)}</p>
+</li>`; //Added item.quantity and FinalPrice multiplied by quantity now
 
   return newItem;
 }


### PR DESCRIPTION
Trello card solved: "Currently our addToCart method does not check to see if an item is already in the cart before adding it again. Make this check...if the item is in the cart do not add it again, instead it should increment the quantity."

Changing addToCart() method of ProductDetails class to only add to the cart a product if it is new, if is already in the cart, only will change the quantity by adding 1.
Changed the cart.js in the template literals at the part of "qty: 1" to "qty: ${item.quantity}". and the line of "{item.FinalPrice}" to "{item.FinalPrice * item.quantity).toFixed(2)}".
All works in npm run preview with no errors.